### PR TITLE
Adding rack-test gem to development requirements

### DIFF
--- a/monittr.gemspec
+++ b/monittr.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "turn"
   s.add_development_dependency "fakeweb"
   s.add_development_dependency "mocha"
+  s.add_development_dependency "rack-test"
 
   s.description = <<-DESC
     Monittr provides a Ruby interface for loading and displaying statistics


### PR DESCRIPTION
Adding rack-test gem to development requirements, because it is needed
to passing tests.
