### PR TITLE
Adding more parameters to services

### DIFF
--- a/lib/monittr.rb
+++ b/lib/monittr.rb
@@ -91,6 +91,12 @@ module Monittr
       def initialize(xml)
         @xml = xml
         super( { :name      => value('name'                          ),
+                 :os        => value('//platform/name'               ),
+                 :osversion => value('//platform/release'            ),
+                 :arch      => value('//platform/machine',           ),
+                 :memtotal  => value('//platform/memory',       :to_i),
+                 :swaptotal => value('//platform/swap',         :to_i),
+                 :cputotal  => value('//platform/cpu',          :to_i),
                  :status    => value('status',                  :to_i),
                  :monitored => value('monitor',                 :to_i),
                  :load      => value('system/load/avg01',       :to_f),
@@ -111,12 +117,15 @@ module Monittr
     class Filesystem < Base
       def initialize(xml)
         @xml = xml
-        super( { :name      => value('name'                          ),
-                 :status    => value('status',                  :to_i),
-                 :monitored => value('monitor',                 :to_i),
-                 :percent   => value('block/percent',           :to_f),
-                 :usage     => value('block/usage'                   ),
-                 :total     => value('block/total'                   )
+        super( { :name            => value('name'                          ),
+                 :status          => value('status',                  :to_i),
+                 :monitored       => value('monitor',                 :to_i),
+                 :percent         => value('block/percent',           :to_f),
+                 :usage           => value('block/usage'                   ),
+                 :total           => value('block/total'                   ),
+                 :inode_percent   => value('inode/percent',           :to_f),
+                 :inode_usage     => value('inode/usage'                   ),
+                 :inode_total     => value('inode/total'                   )
                } )
         rescue Exception => e
           puts "ERROR: #{e.class} -- #{e.message}, In: #{e.backtrace.first}"
@@ -135,13 +144,16 @@ module Monittr
     class Process < Base
       def initialize(xml)
         @xml = xml
-        super( { :name      => value('name'                          ),
-                 :status    => value('status',                  :to_i),
-                 :monitored => value('monitor',                 :to_i),
-                 :pid       => value('pid',                     :to_i),
-                 :uptime    => value('uptime',                  :to_i),
-                 :memory    => value('memory/percent',          :to_f),
-                 :cpu       => value('cpu/percent',             :to_i)
+        super( { :name            => value('name'                               ),
+                 :status          => value('status',                       :to_i),
+                 :monitored       => value('monitor',                      :to_i),
+                 :pid             => value('pid',                          :to_i),
+                 :uptime          => value('uptime',                       :to_i),
+                 :memory          => value('memory/percent',               :to_f),
+                 :cpu             => value('cpu/percent',                  :to_i),
+                 :total_memory    => value('memory/percenttotal',          :to_f),
+                 :total_cpu       => value('cpu/percenttotal',             :to_i),
+                 :response_time   => value('port/responsetime',            :to_i)
                } )
         rescue Exception => e
           puts "ERROR: #{e.class} -- #{e.message}, In: #{e.backtrace.first}"

--- a/lib/monittr.rb
+++ b/lib/monittr.rb
@@ -93,7 +93,7 @@ module Monittr
         super( { :name      => value('name'                          ),
                  :os        => value('//platform/name'               ),
                  :osversion => value('//platform/release'            ),
-                 :arch      => value('//platform/machine',           ),
+                 :arch      => value('//platform/machine'            ),
                  :memtotal  => value('//platform/memory',       :to_i),
                  :swaptotal => value('//platform/swap',         :to_i),
                  :cputotal  => value('//platform/cpu',          :to_i),

--- a/test/monittr_test.rb
+++ b/test/monittr_test.rb
@@ -73,13 +73,19 @@ module Monittr
       end
 
       should "return system info" do
-        assert_not_nil     @server.system
-        assert_equal 0,    @server.system.status
-        assert_equal 1,    @server.system.monitored
+        assert_not_nil          @server.system
+        assert_equal 0,         @server.system.status
+        assert_equal 1,         @server.system.monitored
         assert_equal 'application.com', @server.system.name
-        assert_equal 5.28, @server.system.load
-        assert_equal 0,    @server.system.status
-        assert_equal 937661, @server.system.uptime
+        assert_equal 5.28,      @server.system.load
+        assert_equal 0,         @server.system.status
+        assert_equal 937661,    @server.system.uptime
+        assert_equal 'FreeBSD', @server.system.os
+        assert_equal '8.1-RELEASE', @server.system.osversion
+        assert_equal 'amd64',   @server.system.arch
+        assert_equal 4,         @server.system.cputotal
+        assert_equal 8373908,   @server.system.memtotal
+        assert_equal nil,       @server.system.swaptotal
       end
 
       should "return filesystems info" do
@@ -91,6 +97,7 @@ module Monittr
         assert_equal 0, filesystem.status
         assert_equal 1, filesystem.monitored
         assert_equal 22.8, filesystem.percent
+        assert_equal 0.8, filesystem.inode_percent
       end
 
       should "return processes info" do


### PR DESCRIPTION
Monit's xml contains more parameters than we already support, it would
be nice if we can support more info about system and services.

New parameters:
- System:
  - os: Operating system
  - osversion: Operating system version
  - arch: Machine architecture
  - cputotal: Total nr. of CPUs
  - memtotal: Total size of memory (in KB) 
  - swaptotal: Total size of swap area (in KB, nil if not supported)
- Filesystem:
  - inode_percent, inode_usage, inode_total: Same values as block, but 
    for inodes
- Process:
  - total_memory: Memory usage of process and all children proces
  - total_cpu: CPU usage of process and all children process
  - response_time: monit supports checking a service within a process
    checking, and adds response time if it's available (or nil if not)

I added tests for these values too, and fixed formatting of source where
it is needed. All tests are passing
