### PR TITLE
Fixing failing timeout test

### DIFF
--- a/test/monittr_test.rb
+++ b/test/monittr_test.rb
@@ -38,12 +38,11 @@ module Monittr
       end
 
       should "timeout properly for non-responding URLs" do
-        RestClient.expects(:get).raises(Timeout::Error)
-        cluster = Monittr::Cluster.new %w[ http://admin:monit@localhost:2812 ]
+        cluster = Monittr::Cluster.new %w[ http://admin@timeout.net:2812 ]
         assert_not_nil cluster.servers
         assert_equal 1, cluster.servers.size
         assert_equal 3, cluster.servers.first.system.status
-        assert_equal 'Timeout::Error', cluster.servers.first.system.name
+        assert_equal 'RestClient::RequestTimeout', cluster.servers.first.system.name
       end
 
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,6 +17,7 @@ class Test::Unit::TestCase
   def setup
     FakeWeb.register_uri(:get, 'http://admin:monit@localhost:2812/_status?format=xml', :body => fixture_file('status.xml'))
     FakeWeb.register_uri(:get, 'http://not-working/_status?format=xml', :body => '', :status => ['500'])
+    FakeWeb.register_uri(:get, 'http://admin@timeout.net:2812/_status?format=xml', :exception => Timeout::Error)
     FakeWeb.allow_net_connect = false
   end
 


### PR DESCRIPTION
Moing to FakeWeb's default timeout mock, because it is more reliable
than mocha's way, and imitates the real situation more closely.
