### PR TITLE
Pulling more information from hosts (type: 4)

### DIFF
--- a/lib/monittr.rb
+++ b/lib/monittr.rb
@@ -165,7 +165,6 @@ module Monittr
                  :monitored     => value('monitor',                 :to_i),
                  :host_name     => value('port/hostname'                 ),
                  :port_number   => value('port/portnumber'               ),
-                 :port_number   => value('port/portnumber'               ),
                  :protocol      => value('port/protocol'                 ),
                  :type          => value('port/type'                     ),
                  :response_time => value('port/responsetime'             )

--- a/lib/monittr.rb
+++ b/lib/monittr.rb
@@ -163,6 +163,11 @@ module Monittr
         super( { :name          => value('name'                          ),
                  :status        => value('status',                  :to_i),
                  :monitored     => value('monitor',                 :to_i),
+                 :host_name     => value('port/hostname'                 ),
+                 :port_number   => value('port/portnumber'               ),
+                 :port_number   => value('port/portnumber'               ),
+                 :protocol      => value('port/protocol'                 ),
+                 :type          => value('port/type'                     ),
                  :response_time => value('port/responsetime'             )
                } )
         rescue Exception => e


### PR DESCRIPTION
Monit hosts return a good amount of information.  It would be nice to have access to the protocol and be able to associate some nice icons with it in a UI.

Production XML snippet here:

```
<service type="4">
  <name>vagrant.local</name>
  <collected_sec>1412698423</collected_sec>
  <collected_usec>937202</collected_usec>
  <status>0</status>
  <status_hint>0</status_hint>
  <monitor>1</monitor>
  <monitormode>0</monitormode>
  <pendingaction>0</pendingaction>
  <port>
    <hostname>127.0.0.1</hostname>
    <portnumber>5432</portnumber>
    <request/>
    <protocol>PGSQL</protocol>
    <type>TCP</type>
    <responsetime>0.001</responsetime>
  </port>
</service>
```
